### PR TITLE
Return error from `parse_header/1` through `body_length/1`.

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -564,14 +564,18 @@ has_body(Req) ->
 %%
 %% The length may not be known if Transfer-Encoding is not identity,
 %% and the body hasn't been read at the time of the call.
--spec body_length(Req) -> {undefined | non_neg_integer(), Req} when Req::req().
+-spec body_length(Req)
+	-> {undefined | non_neg_integer(), Req}
+	| {error, badarg} when Req::req().
 body_length(Req) ->
 	case parse_header(<<"transfer-encoding">>, Req) of
 		{ok, [<<"identity">>], Req2} ->
 			{ok, Length, Req3} = parse_header(<<"content-length">>, Req2, 0),
 			{Length, Req3};
 		{ok, _, Req2} ->
-			{undefined, Req2}
+			{undefined, Req2};
+		{error, badarg} ->
+			{error ,badarg}
 	end.
 
 %% @doc Initialize body streaming and set custom decoding functions.


### PR DESCRIPTION
When the `transfer-encoding` header is invalid (say, a `\r\n`) `{error, badarg}` is returned from `parse_header/1`. Before this possible error was not handled in the case clause and resulted in an error.

This commit adds a clause for this possible error case, and passes it on to the caller.
