### PR TITLE
Whitespace in header names

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -336,7 +336,8 @@ parse_hd_name_ws(<< C, Rest/bits >>, S, M, P, Q, V, H, Name) ->
 	case C of
 		$\s -> parse_hd_name_ws(Rest, S, M, P, Q, V, H, Name);
 		$\t -> parse_hd_name_ws(Rest, S, M, P, Q, V, H, Name);
-		$: -> parse_hd_before_value(Rest, S, M, P, Q, V, H, Name)
+		$: -> parse_hd_before_value(Rest, S, M, P, Q, V, H, Name);
+		_ -> error_terminate(400, S)
 	end.
 
 wait_hd_before_value(Buffer, State=#state{


### PR DESCRIPTION
Return 400 if a non-whitespace comes after the first white-space in a header name. That's not
allowed.

This means input like this will cause a 400
response:

```
Header Name: Value
```
