### PR TITLE
Handle invalid header values

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -420,7 +420,6 @@ parse_hd_value(<<>>, S, M, P, Q, V, H, N, SoFar) ->
 parse_hd_value(_, State, _M, _P, _Q, _V, _H, _N, _SoFar) ->
         error_terminate(400, State).
 
-
 request(B, State=#state{transport=Transport}, M, P, Q, Version, Headers) ->
 	case lists:keyfind(<<"host">>, 1, Headers) of
 		false when Version =:= 'HTTP/1.1' ->

--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -416,7 +416,10 @@ parse_hd_value(<<>>, State=#state{max_header_value_length=MaxLength},
 		_, _, _, _, _, _, SoFar) when byte_size(SoFar) > MaxLength ->
 	error_terminate(400, State);
 parse_hd_value(<<>>, S, M, P, Q, V, H, N, SoFar) ->
-	wait_hd_value(<<>>, S, M, P, Q, V, H, N, SoFar).
+        wait_hd_value(<<>>, S, M, P, Q, V, H, N, SoFar);
+parse_hd_value(_, State, _M, _P, _Q, _V, _H, _N, _SoFar) ->
+        error_terminate(400, State).
+
 
 request(B, State=#state{transport=Transport}, M, P, Q, Version, Headers) ->
 	case lists:keyfind(<<"host">>, 1, Headers) of


### PR DESCRIPTION
We have been seeing errors that look like this:

```
hermes.110374: Error in process <0.25615.993> on node 'hermes@ip-10-190-226-11.ec2.internal' with exit value: {{case_clause,<<73 bytes>>},[{cowboy_protocol,parse_hd_value,9,[{file,"src/cowboy_protocol.erl"},{line,405}]}]}
```

This happens when requests with badly formatted header values arrive. In cowboy at the moment these requests are not handled and cause a case clause crash. The most probable reason for these issues is a badly formatted [multi-line headers](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

This commit will make sure those requests cause a HTTP 400 (bad request).
