### PR TITLE
Invalid header CRLF

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -408,7 +408,9 @@ parse_hd_value(<< $\r, Rest/bits >>, S, M, P, Q, V, Headers, Name, SoFar) ->
 		<< $\n, C, Rest2/bits >> when C =:= $\s; C =:= $\t ->
 			parse_hd_value(Rest2, S, M, P, Q, V, Headers, Name, SoFar);
 		<< $\n, Rest2/bits >> ->
-			parse_header(Rest2, S, M, P, Q, V, [{Name, SoFar}|Headers])
+			parse_header(Rest2, S, M, P, Q, V, [{Name, SoFar}|Headers]);
+		_ ->
+			error_terminate(400, S)
 	end;
 parse_hd_value(<< C, Rest/bits >>, S, M, P, Q, V, H, N, SoFar) ->
 	parse_hd_value(Rest, S, M, P, Q, V, H, N, << SoFar/binary, C >>);


### PR DESCRIPTION
When a request comes in that doesn't use the correct \r\n between headers in HTTP we get the following error:

```
hermes.104453: Error in process <0.14992.7504> on node 'hermes@ip-10-120-198-130.ec2.internal' with exit value: {{case_clause,<<309 bytes>>},[{cowboy_protocol,parse_hd_value,9,[{file,"src/cowboy_protocol.erl"},{line,405}]}]}
```

A header that causes this is something like this:

```
HeaderName: HeaderValue\rHeaderName2: HeaderValue
```

Notice the lack of CRLF.

This commit causes this to return a 400 error.
