### PR TITLE
Workaround HEAD responses with undefined lengths

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -983,7 +983,16 @@ reply(Status, Headers, Body, Req=#http_req{
 	Req3 = case Body of
 		BodyFun when is_function(BodyFun) ->
 			%% We stream the response body until we close the connection.
-			RespConn = close,
+			%% HEAD requests may end up using an empty streaming function
+			%% to avoid setting a 'Content-Length' header when the value
+			%% is unknown, but without wanting to close the connection,
+			%% in which case we respect whatever was set by the response
+			%% in terms of termination. The connection however defaults
+			%% to 'close' if the value is unspecified.
+			RespConn = case Method of
+				<<"HEAD">> -> response_connection(Headers, close);
+				_ -> close
+			end,
 			{RespType, Req2} = if
 				Transport =:= cowboy_spdy ->
 					response(Status, Headers, RespHeaders, [


### PR DESCRIPTION
While Cowboy's strict and always requires to put a content-length in a
response to a HEAD request, the clients Heroku proxies for do not always
end up doing so, and leave the content-length value as missing.

In usual circumstances, this would mean that the connection is
close-delimited, and this is how we treat it (we can't know if it's an
'unknown' value that needs to be streamed, or an omission, and both
happen in the wild).

The issue is that because HEAD responses are often used as an
optimization, closing the connection on these (because we faithfully
replicate the expected 'connection:close' header) ends up being
inefficient in many cases.

Because of this, we use a streaming function with an unknown length that
shortcircuits the creation of content-length headers -- which the
streaming function is meant for -- The issue is that in some
circumstances (HEAD requests) we may want to override the 'close' value
on a case-by-case basis.

This patch lets us do this.
