### PR TITLE
Lower the max timeout value on body fetches to 1s

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -661,7 +661,7 @@ stream_body_recv(MaxLength, Req=#http_req{
 		transport=Transport, socket=Socket, buffer=Buffer,
 		body_state={stream, Length, _, _, _}}) ->
 	%% @todo Allow configuring the timeout.
-	case Transport:recv(Socket, min(Length, MaxLength), 55000) of
+	case Transport:recv(Socket, min(Length, MaxLength), 1000) of
 		{ok, Data} -> transfer_decode(<< Buffer/binary, Data/binary >>,
 			Req#http_req{buffer= <<>>});
 		{error, Reason} -> {error, Reason}

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -40,6 +40,8 @@
 %% some lazy evaluation and cache results when possible.
 -module(cowboy_req).
 
+-define(POLL_INTERVAL, 1000).
+
 %% Request API.
 -export([new/14]).
 -export([method/1]).
@@ -661,7 +663,7 @@ stream_body_recv(MaxLength, Req=#http_req{
 		transport=Transport, socket=Socket, buffer=Buffer,
 		body_state={stream, Length, _, _, _}}) ->
 	%% @todo Allow configuring the timeout.
-	case Transport:recv(Socket, min(Length, MaxLength), 1000) of
+	case Transport:recv(Socket, min(Length, MaxLength), ?POLL_INTERVAL) of
 		{ok, Data} -> transfer_decode(<< Buffer/binary, Data/binary >>,
 			Req#http_req{buffer= <<>>});
 		{error, Reason} -> {error, Reason}


### PR DESCRIPTION
Vegur will take charge of maintaining larger logical counters to better
detect interrupts from its backend.
